### PR TITLE
MUSAP-117: Add support for the UpdateData operation

### DIFF
--- a/app/src/main/java/fi/methics/musap/sdk/api/MusapClient.java
+++ b/app/src/main/java/fi/methics/musap/sdk/api/MusapClient.java
@@ -273,9 +273,20 @@ public class MusapClient {
      *
      * <p><b>Note: Only one connection can be active at a time.</b></p>
      * @param url URL of the MUSAP link service
+     * @param callback Response callback
      */
     public static void enableLink(String url, String fcmToken, MusapCallback<MusapLink> callback) {
         MusapLink link = new MusapLink(url, null);
+        new EnrollDataTask(link, fcmToken, callback, context.get()).executeOnExecutor(executor);
+    }
+
+    /**
+     * Send an updated FCM token to the MUSAP Link. If MUSAP Link is not enabled, this does nothing.
+     * @param callback Response callback
+     */
+    public static void updateFcmToken(String fcmToken, MusapCallback<MusapLink> callback) {
+        MusapLink link = getMusapLink();
+        if (link == null) return;
         new EnrollDataTask(link, fcmToken, callback, context.get()).executeOnExecutor(executor);
     }
 

--- a/app/src/main/java/fi/methics/musap/sdk/internal/async/UpdateDataTask.java
+++ b/app/src/main/java/fi/methics/musap/sdk/internal/async/UpdateDataTask.java
@@ -1,0 +1,35 @@
+package fi.methics.musap.sdk.internal.async;
+
+import android.content.Context;
+
+import fi.methics.musap.sdk.api.MusapCallback;
+import fi.methics.musap.sdk.api.MusapException;
+import fi.methics.musap.sdk.internal.datatype.MusapLink;
+import fi.methics.musap.sdk.internal.util.AsyncTaskResult;
+import fi.methics.musap.sdk.internal.util.MLog;
+import fi.methics.musap.sdk.internal.util.MusapAsyncTask;
+import fi.methics.musap.sdk.internal.util.MusapStorage;
+
+public class UpdateDataTask extends MusapAsyncTask<Boolean>  {
+
+    private final MusapLink link;
+    private final String fcmToken;
+
+    public UpdateDataTask(MusapLink link, String fcmToken, MusapCallback<Boolean> callback, Context context) {
+        super(callback, context);
+        this.link = link;
+        this.fcmToken = fcmToken;
+    }
+
+    @Override
+
+    protected AsyncTaskResult<Boolean> runOperation() throws MusapException {
+        try {
+           boolean success = this.link.updateFcmToken(this.fcmToken);
+           return new AsyncTaskResult<>(success);
+        } catch (Exception e) {
+            MLog.e("Failed", e);
+            throw new MusapException(e);
+        }
+    }
+}

--- a/app/src/main/java/fi/methics/musap/sdk/internal/datatype/coupling/UpdateDataPayload.java
+++ b/app/src/main/java/fi/methics/musap/sdk/internal/datatype/coupling/UpdateDataPayload.java
@@ -1,0 +1,31 @@
+package fi.methics.musap.sdk.internal.datatype.coupling;
+
+import android.util.Base64;
+
+import com.google.gson.Gson;
+import com.google.gson.annotations.SerializedName;
+
+import java.nio.charset.StandardCharsets;
+
+import fi.methics.musap.sdk.internal.util.MLog;
+
+public class UpdateDataPayload {
+
+    @SerializedName("fcmtoken")
+    private final String fcmToken;
+
+    public UpdateDataPayload(String fcmToken) {
+        this.fcmToken = fcmToken;
+    }
+
+    public String toBase64() {
+        String payloadJson = new Gson().toJson(this);
+        MLog.d("Payload=" + payloadJson);
+        String base64 =  Base64.encodeToString(
+                payloadJson.getBytes(StandardCharsets.UTF_8),
+                Base64.NO_WRAP);
+        MLog.d("Base64=" + base64);
+        return base64;
+    }
+
+}

--- a/app/src/main/java/fi/methics/musap/sdk/internal/datatype/coupling/UpdateDataResponsePayload.java
+++ b/app/src/main/java/fi/methics/musap/sdk/internal/datatype/coupling/UpdateDataResponsePayload.java
@@ -1,0 +1,12 @@
+package fi.methics.musap.sdk.internal.datatype.coupling;
+
+
+import fi.methics.musap.sdk.internal.util.MLog;
+
+public class UpdateDataResponsePayload extends ResponsePayload {
+
+    public boolean isSuccess() {
+        MLog.d("Status=" + this.status);
+        return "success".equalsIgnoreCase(this.status);
+    }
+}


### PR DESCRIPTION
This PR adds support for a new operation that can be used to update the FCM token if it changes.