### PR TITLE
Add a basic error handling to coupling

### DIFF
--- a/app/src/main/java/fi/methics/musap/sdk/internal/async/CoupleTask.java
+++ b/app/src/main/java/fi/methics/musap/sdk/internal/async/CoupleTask.java
@@ -35,6 +35,10 @@ public class CoupleTask extends MusapAsyncTask<RelyingParty> {
         try {
             // TODO: Add proper error handling
             RelyingParty rp = link.couple(this.couplingCode, this.appId);
+            if (rp == null) {
+                throw new MusapException("Wrong coupling code");
+            }
+
             new MusapStorage(this.context.get()).storeRelyingParty(rp);
             return new AsyncTaskResult<>(rp);
         } catch (Exception e) {


### PR DESCRIPTION
Bug fix: coupleWithRelyingParty now calls onFailure() when coupling fails. 