### PR TITLE
Keyselectfix

### DIFF
--- a/app/src/main/java/fi/methics/musap/sdk/api/MusapClient.java
+++ b/app/src/main/java/fi/methics/musap/sdk/api/MusapClient.java
@@ -227,6 +227,25 @@ public class MusapClient {
     }
 
     /**
+     * Get a key by KeyID
+     * @param keyid KeyID
+     * @return Key or null if no matching key was found
+     */
+    public static MusapKey getKeyByKeyID(String keyid) {
+        if (keyid == null) return null;
+        MLog.d("Searching for key with KeyID " + keyid);
+        MetadataStorage storage = new MetadataStorage(context.get());
+        for (MusapKey key : storage.listKeys()) {
+            if (keyid.equals(key.getKeyId())) {
+                MLog.d("Found key " + key.getKeyAlias());
+                return key;
+            }
+        }
+        MLog.d("Found no key with KeyID "  + keyid);
+        return null;
+    }
+
+    /**
      * Import MUSAP key data and SSCD details
      * @param data JSON data from another MUSA
      * @throws JsonSyntaxException if data is not parseable

--- a/app/src/main/java/fi/methics/musap/sdk/internal/datatype/coupling/PollResponsePayload.java
+++ b/app/src/main/java/fi/methics/musap/sdk/internal/datatype/coupling/PollResponsePayload.java
@@ -77,6 +77,31 @@ public class PollResponsePayload extends ResponsePayload {
         return this.transId;
     }
 
+    /**
+     * Get the key ID this request is meant for, if any.
+     * @return Key ID, or null if key ID is not in request
+     */
+    public String getKeyId() {
+        if (this.signaturePayload == null || this.signaturePayload.key == null) {
+            return null;
+        }
+
+        return this.signaturePayload.key.keyid;
+    }
+
+    /**
+     * Get the key name this request is meant for, if any.
+     * @return Key name, or null if key ID is not in request
+     */
+    public String getKeyName() {
+        if (this.signaturePayload == null || this.signaturePayload.key == null) {
+            return null;
+        }
+
+        return this.signaturePayload.key.keyname;
+    }
+
+
     public SignatureReq toSignatureReq(MusapKey key) throws MusapException {
         SignatureReq req = this.signaturePayload.toSignatureReq(key);
         req.setTransId(this.transId);

--- a/app/src/main/java/fi/methics/musap/sdk/internal/datatype/coupling/SignaturePayload.java
+++ b/app/src/main/java/fi/methics/musap/sdk/internal/datatype/coupling/SignaturePayload.java
@@ -45,10 +45,6 @@ public class SignaturePayload {
     @SerializedName("attributes")
     public List<SignatureAttribute> attributes;
 
-    @SerializedName("genkey")
-    public boolean genkey;
-
-
     /**
      * Data choice for cases where user's chosen keystore defines signed data,
      * such as document signing.

--- a/app/src/main/java/fi/methics/musap/sdk/sscd/yubikey/YubiKeyOpenPgpSscd.java
+++ b/app/src/main/java/fi/methics/musap/sdk/sscd/yubikey/YubiKeyOpenPgpSscd.java
@@ -5,6 +5,7 @@ import android.app.AlertDialog;
 import android.content.Context;
 import android.view.LayoutInflater;
 import android.view.View;
+import android.widget.RadioGroup;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -24,7 +25,6 @@ import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
 import org.bouncycastle.asn1.x9.X9ObjectIdentifiers;
 import org.bouncycastle.cert.X509v3CertificateBuilder;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.operator.ContentSigner;
 
 import java.io.ByteArrayInputStream;
@@ -33,7 +33,6 @@ import java.io.OutputStream;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.security.PublicKey;
-import java.security.Security;
 import java.security.Signature;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
@@ -49,8 +48,8 @@ import fi.methics.musap.sdk.internal.datatype.MusapCertificate;
 import fi.methics.musap.sdk.internal.datatype.MusapKey;
 import fi.methics.musap.sdk.internal.datatype.MusapLoA;
 import fi.methics.musap.sdk.internal.datatype.MusapSignature;
-import fi.methics.musap.sdk.internal.datatype.SscdInfo;
 import fi.methics.musap.sdk.internal.datatype.SignatureFormat;
+import fi.methics.musap.sdk.internal.datatype.SscdInfo;
 import fi.methics.musap.sdk.internal.discovery.KeyBindReq;
 import fi.methics.musap.sdk.internal.keygeneration.KeyGenReq;
 import fi.methics.musap.sdk.internal.sign.SignatureReq;
@@ -85,6 +84,9 @@ public class YubiKeyOpenPgpSscd implements MusapSscdInterface<YubiKeySettings> {
 
     private KeyGenReq keyGenReq;
     private SignatureReq sigReq;
+
+    // Yubikey API supports signing only with the signature key slot.
+    private KeyRef slot = KeyRef.SIG;
 
     private final Context c;
 
@@ -303,7 +305,7 @@ public class YubiKeyOpenPgpSscd implements MusapSscdInterface<YubiKeySettings> {
                 .setCountry("FI")
                 .setProvider("Yubico")
                 .setKeygenSupported(true)
-                .setSupportedAlgorithms(Arrays.asList(KeyAlgorithm.ECC_P256_K1, KeyAlgorithm.ECC_P384_K1))
+                .setSupportedAlgorithms(Arrays.asList(KeyAlgorithm.ECC_P256_K1, KeyAlgorithm.ECC_ED25519))
                 .setSupportedFormats(Arrays.asList(SignatureFormat.RAW))
                 .build();
     }
@@ -377,7 +379,17 @@ public class YubiKeyOpenPgpSscd implements MusapSscdInterface<YubiKeySettings> {
 
         MLog.d("Trying to generate a key");
 
-        PublicKey publicKey = openpgp.generateEcKey(KeyRef.SIG, OpenPgpCurve.Ed25519).toPublicKey();
+        OpenPgpCurve curve;
+        if (req.getAlgorithm() == null || req.getAlgorithm().equals(KeyAlgorithm.ECC_ED25519)) {
+            curve = OpenPgpCurve.Ed25519;
+        } else  if (req.getAlgorithm().equals(KeyAlgorithm.ECC_P256_K1)) {
+            curve = OpenPgpCurve.SECP256K1;
+        } else {
+            MLog.e("Unsupported algoritm " + req.getAlgorithm());
+            throw new IllegalArgumentException("Unsupported algoritm " + req.getAlgorithm());
+        }
+
+        PublicKey publicKey = openpgp.generateEcKey(this.slot, curve).toPublicKey();
         openpgp.verifyUserPin(pin.toCharArray(), false);
         MLog.d("Generated KeyPair");
 
@@ -423,7 +435,7 @@ public class YubiKeyOpenPgpSscd implements MusapSscdInterface<YubiKeySettings> {
         X509Certificate builtCert = (X509Certificate) CertificateFactory.getInstance("X.509")
                 .generateCertificate(new ByteArrayInputStream(certBytes));
 
-        openpgp.putCertificate(KeyRef.SIG, builtCert);
+        openpgp.putCertificate(this.slot, builtCert);
         MLog.d("Put certificate to slot");
 
         MusapCertificate cert = new MusapCertificate(builtCert);
@@ -448,22 +460,18 @@ public class YubiKeyOpenPgpSscd implements MusapSscdInterface<YubiKeySettings> {
 
         try {
             OpenPgpSession openpgp = new OpenPgpSession(connection);
-
             MLog.d("Opened OpenPGP session");
-
             MLog.d("Device supports ECC=" + openpgp.supports(OpenPgpSession.FEATURE_EC_KEYS));
 
-            Security.removeProvider("BC");
-            Security.insertProviderAt(new BouncyCastleProvider(), 1);
             openpgp.verifyUserPin(pin.toCharArray(), false);
+
+            if (!isSerialCorrect(openpgp.getAid().getSerial(), sigReq.getKey())) {
+                MLog.e("Wrong serial key");
+                throw new MusapException(MusapException.ERROR_WRONG_PARAM, "Wrong serial key");
+            }
 
             byte[] message = sigReq.getData();
             byte[] sigResult = openpgp.sign(message);
-
-            Signature verifier = Signature.getInstance("Ed25519");
-            verifier.initVerify(openpgp.getPublicKey(KeyRef.SIG).toPublicKey());
-            verifier.update(message);
-            MLog.d("Signature valid=" + verifier.verify(sigResult));
 
             // Dismiss old dialog if it it showing
             getActivity().runOnUiThread(() -> {
@@ -491,6 +499,20 @@ public class YubiKeyOpenPgpSscd implements MusapSscdInterface<YubiKeySettings> {
         c.setTime(new Date());
         c.add(Calendar.YEAR, 5);
         return c.getTime();
+    }
+
+    private boolean isSerialCorrect(int deviceSerial, MusapKey key) {
+        String received = Integer.toHexString(deviceSerial);
+        String stored = key.getAttributeValue(ATTRIBUTE_SERIAL);
+
+        if (key.getAttribute(ATTRIBUTE_SERIAL) == null) {
+            MLog.d("No serial saved");
+            return true;
+        } else {
+            MLog.d("Received serial=" + received);
+            MLog.d("Stored serial  =" + stored);
+            return stored.equalsIgnoreCase(received);
+        }
     }
 
 }

--- a/app/src/main/java/fi/methics/musap/sdk/sscd/yubikey/YubiKeyOpenPgpSscd.java
+++ b/app/src/main/java/fi/methics/musap/sdk/sscd/yubikey/YubiKeyOpenPgpSscd.java
@@ -398,7 +398,7 @@ public class YubiKeyOpenPgpSscd implements MusapSscdInterface<YubiKeySettings> {
             curve = OpenPgpCurve.SECP256K1;
         } else {
             MLog.e("Unsupported algoritm " + req.getAlgorithm());
-            throw new IllegalArgumentException("Unsupported algoritm " + req.getAlgorithm());
+            throw new IllegalArgumentException("Unsupported algorithm " + req.getAlgorithm());
         }
 
         PublicKey publicKey = openpgp.generateEcKey(this.slot, curve).toPublicKey();

--- a/app/src/main/res/layout/dialog_keygen_failed.xml
+++ b/app/src/main/res/layout/dialog_keygen_failed.xml
@@ -10,6 +10,13 @@
         android:id="@+id/text_insert_yubikey"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
         android:text="Failed to generate key"
         android:textAppearance="@style/TextAppearance.AppCompat.Medium" />
+
+    <TextView
+        android:id="@+id/text_fail_reason"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp" />
 </LinearLayout>

--- a/app/src/main/res/layout/dialog_pin.xml
+++ b/app/src/main/res/layout/dialog_pin.xml
@@ -19,4 +19,5 @@
             android:layout_height="wrap_content"
             android:inputType="numberDecimal" />
     </com.google.android.material.textfield.TextInputLayout>
+
 </LinearLayout>

--- a/app/src/main/res/layout/dialog_sign_failed.xml
+++ b/app/src/main/res/layout/dialog_sign_failed.xml
@@ -10,6 +10,14 @@
         android:id="@+id/text_insert_yubikey"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
         android:text="Failed to sign"
+        android:textAppearance="@style/TextAppearance.AppCompat.Medium" />
+
+    <TextView
+        android:id="@+id/text_sign_fail_reason"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
         android:textAppearance="@style/TextAppearance.AppCompat.Medium" />
 </LinearLayout>


### PR DESCRIPTION
Added a serial number check for Yubikeys. Trying to sign with a device other than the one where the key was generated is not possible. 

Fixed Divvy not checking signature request key id. 